### PR TITLE
fix(ci): allow long commit bodies in commitlint

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -17,6 +17,8 @@ const allowedScopes = [
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
     "scope-empty": [2, "never"],
     "scope-enum": [2, "always", allowedScopes],
     "subject-case": [


### PR DESCRIPTION
## Summary

- Fixes `main` CI failing during the commitlint job after squash merges.
- Keeps Conventional Commit validation for commit type, scope, and subject.
- Disables body and footer line-length checks so GitHub-generated PR merge bodies do not fail CI.

## Why

The dependency update PR merged successfully, but the subsequent `push` workflow on `main` failed because the squash merge commit body included lines longer than 100 characters. The commit subject was valid; only the inherited `body-max-line-length` rule failed.

## Validation

- [x] `git show -s --format=%B 08504e3 | npx commitlint --verbose`
- [x] `npm run lint`
